### PR TITLE
skip servicemonitor validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 validate-manifest:
-	oc process --local=true -f openshift/template.yaml | kubeconform -strict -verbose -
+	oc process --local=true -f openshift/template.yaml | kubeconform -strict -verbose -skip ServiceMonitor -
 
 validate-dashboards:
 	kubeconform -strict -verbose dashboards/


### PR DESCRIPTION
Could not configure custom schema validation, so let's just skip it for now.
Will add it  in the future