### PR TITLE
relabel cluster to not include account number

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -110,8 +110,13 @@ objects:
     endpoints:
     - interval: 30s
       path: /metrics
-      port: 9108
+      port: "9108"
       scheme: http
+      metricRelabelings:
+      - source_labels: [cluster]
+        regex:  '\d+:(.*)'
+        replacement: '$1'
+        target_label: cluster
     namespaceSelector:
       matchNames:
       - ${NAMESPACE}


### PR DESCRIPTION
This will (hopefully) relabel cluster values from something like `999999999999:my-integration-instance` to `my-integration-instance`.
Also fixes integer port number that should be string