### PR TITLE
rename service monitor to avoid conflicts

### DIFF
--- a/openshift/template-monitoring.yaml
+++ b/openshift/template-monitoring.yaml
@@ -1,14 +1,14 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: assisted-events-scrape
+  name: assisted-opensearch
 objects:
 - apiVersion: monitoring.coreos.com/v1
   kind: ServiceMonitor
   metadata:
     labels:
       prometheus: app-sre
-    name: servicemonitor-assisted-installer-opensearch
+    name: servicemonitor-assisted-opensearch-${NAMESPACE}
   spec:
     endpoints:
     - interval: 30s

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: assisted-events-scrape
+  name: assisted-opensearch
 objects:
 - kind: Service
   apiVersion: v1


### PR DESCRIPTION
As integration and stage will deploy to the same namespace, we need to name the servicemonitor accordingly