### PR TITLE
bugfix: servicemonitor needs port name not port number

### DIFF
--- a/openshift/template-monitoring.yaml
+++ b/openshift/template-monitoring.yaml
@@ -13,7 +13,7 @@ objects:
     endpoints:
     - interval: 30s
       path: /metrics
-      port: "9108"
+      port: "http"
       scheme: http
       metricRelabelings:
       - source_labels: [cluster]


### PR DESCRIPTION
According to prometheus troubleshooting we need to declare port name in the `port` attribute, not port number
https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/troubleshooting.md