### PR TITLE
bugfix: casing for servicemonitor is different than prometheus config

### DIFF
--- a/openshift/template-monitoring.yaml
+++ b/openshift/template-monitoring.yaml
@@ -16,10 +16,10 @@ objects:
       port: "http"
       scheme: http
       metricRelabelings:
-      - source_labels: [cluster]
+      - sourceLabels: [cluster]
         regex:  '\d+:(.*)'
         replacement: '$1'
-        target_label: cluster
+        targetLabel: cluster
     namespaceSelector:
       matchNames:
       - ${NAMESPACE}


### PR DESCRIPTION
This PR fixes this error from prometheus
`msg="skipping servicemonitor" error="relabel configuration for replace action needs targetLabel value"`